### PR TITLE
fix version requirement to use correct syntax

### DIFF
--- a/lib/HTML/Make/Page.pm
+++ b/lib/HTML/Make/Page.pm
@@ -10,7 +10,7 @@ our %EXPORT_TAGS = (
     all => \@EXPORT_OK,
 );
 our $VERSION = '0.03';
-use HTML::Make '0.16';
+use HTML::Make 0.16;
 
 sub add_meta
 {


### PR DESCRIPTION
Version numbers on a use line need to be unquoted to be handled properly. When they are quoted, they are passed in import instead. Part versions of perl ignored these arguments, but future versions are intending to throw errors for arguments given to an undefined import method.